### PR TITLE
fixes a bug where specfile.tplis not included during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     long_description=long_description,
     download_url=download_url,
     packages=['pypi2spec'],
+    include_package_data=True,
     install_requires=requirements,
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
Added include_package_data to setup.py, fixes a bug where specfile.tpl was not included during install
