### PR TITLE
Update pypi2spec.spec

### DIFF
--- a/pypi2spec.spec
+++ b/pypi2spec.spec
@@ -1,6 +1,6 @@
 Name:           pypi2spec
 Version:        0.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Python script to generate RPM spec file for PyPI projects
 License:        GPLv3+
 URL:            http://github.com/pypingou/pypi2spec
@@ -32,6 +32,9 @@ install -pm644 pypi2spec/specfile.tpl %{buildroot}%{python2_sitelib}/pypi2spec/
 %{python2_sitelib}/*
 
 %changelog
+* Tue Dec 10 2013 Christopher Meng <rpm@cicku.me> - 0.3.0-2
+- Beautify SPEC syntax.
+
 * Mon Dec 17 2012 Pierre-Yves Chibon <pingou@pingoured.fr> - 0.3.0-1
 - Update to 0.3.0
 


### PR DESCRIPTION
1. Use install -m to remove executable bits directly.
2. Use %__python2 macro instead of %__python to avoid mess after moving to Py3 stack.
3. Use more standardized macro for python 2.x package.
4. Remove obsoleted lines.
5. Small cleanup of English.
6. Use %{buildroot} macro only instead of mixed using.
